### PR TITLE
Make it possible to override the base, src, dest config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # preact-cli-plugin-critical-css
 
-
 [Preact CLI] plugin that adds critical css to your [pre-rendered] routes using [html-critical-webpack-plugin].
 
 ## Installation
+
 Install via npm:
+
 ```bash
 npm i -D preact-cli-plugin-critical-css
 ```
+
 or yarn:
+
 ```bash
 yarn add preact-cli-plugin-critical-css --dev
 ```
@@ -16,22 +19,60 @@ yarn add preact-cli-plugin-critical-css --dev
 then include it in your project by creating a `preact.config.js` file:
 
 ```js
-import criticalCssPlugin from 'preact-cli-plugin-critical-css';
+import criticalCssPlugin from "preact-cli-plugin-critical-css";
 
 export default (config, env) => {
-  const options = {...}; // passed directly to the 'critical' module
-  criticalCssPlugin(config, env, options);
-}
+	const options = {
+		// passed directly to the 'critical' module
+		// This is optional
+	};
+
+	criticalCssPlugin(config, env, options);
+};
+```
+
+## Default options
+
+The plugin sets some default options. Below you find an overview of this options.
+Ofcourse, it's possible to override these in the options object.
+
+```js
+const defaultOptions = {
+	// Inline the generated critical-path CSS.
+	inline: true,
+
+	// Minify critical-path CSS when inlining.
+	minify: true,
+
+	// Extract inlined styles from referenced stylesheets.
+	extract: false,
+
+	// Viewport width
+	width: 1280,
+
+	// Viewport height.
+	height: 600,
+
+	// Your build directory to find css files.
+	base: path.resolve(env.dest),
+
+	// The path to a prerendered route. (e.g. index.html)
+	src: filePath,
+
+	// Write the generated critical-path CSS to this file.
+	dest: filePath
+};
 ```
 
 ## Configuration
+
 Full list of possible options that are passed to [critical] are available [here](https://github.com/addyosmani/critical#usage).
 
 ## License
 
 MIT © [matthewlynch](https://github.com/matthewlynch)
 
-[Preact CLI]: https://github.com/developit/preact-cli
+[preact cli]: https://github.com/developit/preact-cli
 [pre-rendered]: https://github.com/developit/preact-cli#pre-rendering
 [critical]: https://github.com/addyosmani/critical
 [html-critical-webpack-plugin]: https://github.com/anthonygore/html-critical-webpack-plugin

--- a/src/index.js
+++ b/src/index.js
@@ -38,12 +38,12 @@ function preactCliCriticalCssPlugin(config, env, options) {
 					new HtmlCriticalPlugin(
 						merge.all([
 							defaults,
-							opts,
 							{
 								base: path.resolve(env.dest),
 								src: filePath,
 								dest: filePath
-							}
+							},
+							opts,
 						])
 					)
 				);


### PR DESCRIPTION
Hello! 

I've a use case where I need to modify the base and source path.
I don't know if it was intentional to make sure no one can override these 3 options (base, src, dest).

With this PR, the passed options will always have a higher priority; and thus it's more configurable if needed.

I'm looking forward to receiving your feedback

Thank you!